### PR TITLE
Utils rounding difference between python 2 and 3

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,8 +22,8 @@ def test_shouldCalculateAmountPriceDiscount():
     }
     discount = utils.calculate_discount(base_price, voucher, unit_price)
     price = utils.calculate_price(base_price, voucher, unit_price)
-    assert discount == 124
-    assert price == 960.85
+    assert discount == 124.36
+    assert price == 960.49
 
 def test_shouldCalculateAmountDiscountWhenGiftIsNone():
     voucher = {
@@ -44,5 +44,5 @@ def test_shouldCalculateAmountDiscountWhenGiftIsNone():
     }
     discount = utils.calculate_discount(base_price, voucher, unit_price)
     price = utils.calculate_price(base_price, voucher, unit_price)
-    assert discount == 124
-    assert price == 960.85
+    assert discount == 124.36
+    assert price == 960.49

--- a/voucherify/utils.py
+++ b/voucherify/utils.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 def round_money(value):
     if value is None or value < 0:
         raise Exception('Invalid value, amount should be a number and higher than zero.')
@@ -24,7 +26,7 @@ def calculate_price(base_price, voucher, unit_price):
     
     if getattr(voucher, 'gift', None) is not None:
         discount = min(voucher['gift']['balance'] / e, base_price)
-        return round_money(base_price - discount)       
+        return round_money(base_price - discount)
     
     if 'discount' not in voucher:
         raise Exception('Unsupported voucher type.')


### PR DESCRIPTION
utils methods that calculate discount and discounted price are rounding results differently for different python versions

python 2: results are rounded to 0 decimals (123.456 -> 123)
python 3: results are rounded to 2 decimals (123.456 -> 123.46)

we want the utils to always round the results to 2 decimal places (**123.456 -> 123.46**) regardless of python version