### PR TITLE
Fixes issue 38: Allow custom timeout to be passed in Client init.

### DIFF
--- a/voucherify/client.py
+++ b/voucherify/client.py
@@ -8,12 +8,12 @@ except ImportError:
     from urllib import quote
 
 ENDPOINT_URL = 'https://api.voucherify.io'
-TIMEOUT = 30 * 1000
+TIMEOUT = 30
 
 
 class VoucherifyRequest(object):
-    def __init__(self, application_id, client_secret_key, api_endpoint=None):
-        self.timeout = TIMEOUT
+    def __init__(self, application_id, client_secret_key, api_endpoint=None, timeout=TIMEOUT):
+        self.timeout = timeout
         self.url = (api_endpoint if api_endpoint else ENDPOINT_URL) + "/v1"
         self.headers = {
             'X-App-Id': application_id,


### PR DESCRIPTION
Fixes issue: https://github.com/voucherifyio/voucherify-python-sdk/issues/38 by reducing the default timeout from 500 minutes to 30 seconds, and allows a custom timeout to be passing in the client init.