### PR TITLE
v2.2.1 - upload new pypi version

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Bug reports and pull requests are welcome through [GitHub Issues](https://github
 
 ## Changelog
 
+- **2021-05-26** - `2.2.1`
+  - Upload new version to pypi.org. No changes compared to `2.2.0`
 - **2021-05-20** - `2.2.0`
   - Added `client.validations*` member
   - Added method `validateVoucher` to `client.validations`

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'voucherify'))
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 __pypi_username__ = 'voucherify'
 __pypi_packagename__ = 'voucherify'
 __github_username__ = 'voucherifyio'


### PR DESCRIPTION
New version was uplodad to pypi.org, since there were issues with .egg files, had to make them in tar.gz. 
Not possible to overwrite current version ⟶ therefore need to bump current version .