### PR TITLE
v5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Remember that this SDK is auto generated (except of the tests) so changes made h
 
 ## 📅 Changelog
 
+- **2024-11-04** - `5.0.1`
+  - Added support for returning `campaign_id` and `campaign_name` in stackable validation endpoint, when `redeemable` option is expanded
 - **2024-10-28** - `5.0.0`
   - Added missing `enums` in few filters models
   - !!! BREAKING CHANGES !!!

--- a/docs/ClientValidationsValidateResponseBodyRedeemablesItem.md
+++ b/docs/ClientValidationsValidateResponseBodyRedeemablesItem.md
@@ -14,6 +14,8 @@ Name | Type | Description | Notes
 **result** | [**ClientValidationsValidateResponseBodyRedeemablesItemResult**](ClientValidationsValidateResponseBodyRedeemablesItemResult.md) |  | [optional] 
 **metadata** | **object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] 
 **categories** | [**List[CategoryWithStackingRulesType]**](CategoryWithStackingRulesType.md) |  | [optional] 
+**campaign_name** | **str** | Campaign name | [optional] 
+**campaign_id** | **str** | Unique campaign ID assigned by Voucherify. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/ValidationsRedeemableInapplicable.md
+++ b/docs/ValidationsRedeemableInapplicable.md
@@ -11,6 +11,8 @@ Name | Type | Description | Notes
 **result** | [**ValidationsRedeemableInapplicableResult**](ValidationsRedeemableInapplicableResult.md) |  | [optional] 
 **metadata** | **object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] 
 **categories** | [**List[CategoryWithStackingRulesType]**](CategoryWithStackingRulesType.md) |  | [optional] 
+**campaign_name** | **str** | Campaign name | [optional] 
+**campaign_id** | **str** | Unique campaign ID assigned by Voucherify. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/ValidationsRedeemableSkipped.md
+++ b/docs/ValidationsRedeemableSkipped.md
@@ -11,6 +11,8 @@ Name | Type | Description | Notes
 **result** | [**ValidationsRedeemableSkippedResult**](ValidationsRedeemableSkippedResult.md) |  | [optional] 
 **metadata** | **object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] 
 **categories** | [**List[CategoryWithStackingRulesType]**](CategoryWithStackingRulesType.md) |  | [optional] 
+**campaign_name** | **str** | Campaign name | [optional] 
+**campaign_id** | **str** | Unique campaign ID assigned by Voucherify. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/ValidationsValidateResponseBodyRedeemablesItem.md
+++ b/docs/ValidationsValidateResponseBodyRedeemablesItem.md
@@ -14,6 +14,8 @@ Name | Type | Description | Notes
 **result** | [**ValidationsValidateResponseBodyRedeemablesItemResult**](ValidationsValidateResponseBodyRedeemablesItemResult.md) |  | [optional] 
 **metadata** | **object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] 
 **categories** | [**List[CategoryWithStackingRulesType]**](CategoryWithStackingRulesType.md) |  | [optional] 
+**campaign_name** | **str** | Campaign name | [optional] 
+**campaign_id** | **str** | Unique campaign ID assigned by Voucherify. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "voucherify"
-version = "5.0.0"
+version = "5.0.1"
 description = "Voucherify API"
 authors = ["Voucherify Team <support@voucherify.io>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 NAME = "voucherify"
-VERSION = "5.0.0"
+VERSION = "5.0.1"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
     "urllib3 >= 1.25.3, < 2.1.0",

--- a/voucherify/__init__.py
+++ b/voucherify/__init__.py
@@ -15,7 +15,7 @@
 """  # noqa: E501
 
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 # import apis into sdk package
 from voucherify.api.async_actions_api import AsyncActionsApi

--- a/voucherify/api_client.py
+++ b/voucherify/api_client.py
@@ -88,13 +88,13 @@ class ApiClient:
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {
             "X-Voucherify-Channel": "Python-SDK",
-            "User-Agent": "OpenAPI-Python-SDK/5.0.0"
+            "User-Agent": "OpenAPI-Python-SDK/5.0.1"
         }
         if header_name is not None:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Python-SDK/5.0.0'
+        self.user_agent = 'OpenAPI-Python-SDK/5.0.1'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/voucherify/configuration.py
+++ b/voucherify/configuration.py
@@ -459,7 +459,7 @@ conf = voucherify.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v2018-08-01\n"\
-               "SDK Package Version: 5.0.0".\
+               "SDK Package Version: 5.0.1".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/voucherify/models/client_validations_validate_response_body_redeemables_item.py
+++ b/voucherify/models/client_validations_validate_response_body_redeemables_item.py
@@ -41,7 +41,9 @@ class ClientValidationsValidateResponseBodyRedeemablesItem(BaseModel):
     result: Optional[ClientValidationsValidateResponseBodyRedeemablesItemResult] = None
     metadata: Optional[Dict[str, Any]] = Field(default=None, description="The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.")
     categories: Optional[List[CategoryWithStackingRulesType]] = None
-    __properties: ClassVar[List[str]] = ["status", "id", "object", "order", "applicable_to", "inapplicable_to", "result", "metadata", "categories"]
+    campaign_name: Optional[StrictStr] = Field(default=None, description="Campaign name")
+    campaign_id: Optional[StrictStr] = Field(default=None, description="Unique campaign ID assigned by Voucherify.")
+    __properties: ClassVar[List[str]] = ["status", "id", "object", "order", "applicable_to", "inapplicable_to", "result", "metadata", "categories", "campaign_name", "campaign_id"]
 
     @field_validator('status')
     def status_validate_enum(cls, value):
@@ -141,6 +143,16 @@ class ClientValidationsValidateResponseBodyRedeemablesItem(BaseModel):
         if self.categories is None and "categories" in self.model_fields_set:
             _dict['categories'] = None
 
+        # set to None if campaign_name (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_name is None and "campaign_name" in self.model_fields_set:
+            _dict['campaign_name'] = None
+
+        # set to None if campaign_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_id is None and "campaign_id" in self.model_fields_set:
+            _dict['campaign_id'] = None
+
         return _dict
 
     @classmethod
@@ -161,7 +173,9 @@ class ClientValidationsValidateResponseBodyRedeemablesItem(BaseModel):
             "inapplicable_to": InapplicableToResultList.from_dict(obj["inapplicable_to"]) if obj.get("inapplicable_to") is not None else None,
             "result": ClientValidationsValidateResponseBodyRedeemablesItemResult.from_dict(obj["result"]) if obj.get("result") is not None else None,
             "metadata": obj.get("metadata"),
-            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None
+            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None,
+            "campaign_name": obj.get("campaign_name"),
+            "campaign_id": obj.get("campaign_id")
         })
         return _obj
 

--- a/voucherify/models/validations_redeemable_inapplicable.py
+++ b/voucherify/models/validations_redeemable_inapplicable.py
@@ -35,7 +35,9 @@ class ValidationsRedeemableInapplicable(BaseModel):
     result: Optional[ValidationsRedeemableInapplicableResult] = None
     metadata: Optional[Dict[str, Any]] = Field(default=None, description="The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.")
     categories: Optional[List[CategoryWithStackingRulesType]] = None
-    __properties: ClassVar[List[str]] = ["status", "id", "object", "result", "metadata", "categories"]
+    campaign_name: Optional[StrictStr] = Field(default=None, description="Campaign name")
+    campaign_id: Optional[StrictStr] = Field(default=None, description="Unique campaign ID assigned by Voucherify.")
+    __properties: ClassVar[List[str]] = ["status", "id", "object", "result", "metadata", "categories", "campaign_name", "campaign_id"]
 
     @field_validator('status')
     def status_validate_enum(cls, value):
@@ -136,6 +138,16 @@ class ValidationsRedeemableInapplicable(BaseModel):
         if self.categories is None and "categories" in self.model_fields_set:
             _dict['categories'] = None
 
+        # set to None if campaign_name (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_name is None and "campaign_name" in self.model_fields_set:
+            _dict['campaign_name'] = None
+
+        # set to None if campaign_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_id is None and "campaign_id" in self.model_fields_set:
+            _dict['campaign_id'] = None
+
         return _dict
 
     @classmethod
@@ -153,7 +165,9 @@ class ValidationsRedeemableInapplicable(BaseModel):
             "object": obj.get("object"),
             "result": ValidationsRedeemableInapplicableResult.from_dict(obj["result"]) if obj.get("result") is not None else None,
             "metadata": obj.get("metadata"),
-            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None
+            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None,
+            "campaign_name": obj.get("campaign_name"),
+            "campaign_id": obj.get("campaign_id")
         })
         return _obj
 

--- a/voucherify/models/validations_redeemable_skipped.py
+++ b/voucherify/models/validations_redeemable_skipped.py
@@ -35,7 +35,9 @@ class ValidationsRedeemableSkipped(BaseModel):
     result: Optional[ValidationsRedeemableSkippedResult] = None
     metadata: Optional[Dict[str, Any]] = Field(default=None, description="The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.")
     categories: Optional[List[CategoryWithStackingRulesType]] = None
-    __properties: ClassVar[List[str]] = ["status", "id", "object", "result", "metadata", "categories"]
+    campaign_name: Optional[StrictStr] = Field(default=None, description="Campaign name")
+    campaign_id: Optional[StrictStr] = Field(default=None, description="Unique campaign ID assigned by Voucherify.")
+    __properties: ClassVar[List[str]] = ["status", "id", "object", "result", "metadata", "categories", "campaign_name", "campaign_id"]
 
     @field_validator('status')
     def status_validate_enum(cls, value):
@@ -136,6 +138,16 @@ class ValidationsRedeemableSkipped(BaseModel):
         if self.categories is None and "categories" in self.model_fields_set:
             _dict['categories'] = None
 
+        # set to None if campaign_name (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_name is None and "campaign_name" in self.model_fields_set:
+            _dict['campaign_name'] = None
+
+        # set to None if campaign_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_id is None and "campaign_id" in self.model_fields_set:
+            _dict['campaign_id'] = None
+
         return _dict
 
     @classmethod
@@ -153,7 +165,9 @@ class ValidationsRedeemableSkipped(BaseModel):
             "object": obj.get("object"),
             "result": ValidationsRedeemableSkippedResult.from_dict(obj["result"]) if obj.get("result") is not None else None,
             "metadata": obj.get("metadata"),
-            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None
+            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None,
+            "campaign_name": obj.get("campaign_name"),
+            "campaign_id": obj.get("campaign_id")
         })
         return _obj
 

--- a/voucherify/models/validations_validate_response_body_redeemables_item.py
+++ b/voucherify/models/validations_validate_response_body_redeemables_item.py
@@ -41,7 +41,9 @@ class ValidationsValidateResponseBodyRedeemablesItem(BaseModel):
     result: Optional[ValidationsValidateResponseBodyRedeemablesItemResult] = None
     metadata: Optional[Dict[str, Any]] = Field(default=None, description="The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.")
     categories: Optional[List[CategoryWithStackingRulesType]] = None
-    __properties: ClassVar[List[str]] = ["status", "id", "object", "order", "applicable_to", "inapplicable_to", "result", "metadata", "categories"]
+    campaign_name: Optional[StrictStr] = Field(default=None, description="Campaign name")
+    campaign_id: Optional[StrictStr] = Field(default=None, description="Unique campaign ID assigned by Voucherify.")
+    __properties: ClassVar[List[str]] = ["status", "id", "object", "order", "applicable_to", "inapplicable_to", "result", "metadata", "categories", "campaign_name", "campaign_id"]
 
     @field_validator('status')
     def status_validate_enum(cls, value):
@@ -141,6 +143,16 @@ class ValidationsValidateResponseBodyRedeemablesItem(BaseModel):
         if self.categories is None and "categories" in self.model_fields_set:
             _dict['categories'] = None
 
+        # set to None if campaign_name (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_name is None and "campaign_name" in self.model_fields_set:
+            _dict['campaign_name'] = None
+
+        # set to None if campaign_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.campaign_id is None and "campaign_id" in self.model_fields_set:
+            _dict['campaign_id'] = None
+
         return _dict
 
     @classmethod
@@ -161,7 +173,9 @@ class ValidationsValidateResponseBodyRedeemablesItem(BaseModel):
             "inapplicable_to": InapplicableToResultList.from_dict(obj["inapplicable_to"]) if obj.get("inapplicable_to") is not None else None,
             "result": ValidationsValidateResponseBodyRedeemablesItemResult.from_dict(obj["result"]) if obj.get("result") is not None else None,
             "metadata": obj.get("metadata"),
-            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None
+            "categories": [CategoryWithStackingRulesType.from_dict(_item) for _item in obj["categories"]] if obj.get("categories") is not None else None,
+            "campaign_name": obj.get("campaign_name"),
+            "campaign_id": obj.get("campaign_id")
         })
         return _obj
 


### PR DESCRIPTION
- **2024-11-04** - `5.0.1`
  - Added support for returning `campaign_id` and `campaign_name` in stackable validation endpoint, when `redeemable` option is expanded